### PR TITLE
Enable snap sync and add hardware section

### DIFF
--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -19,6 +19,19 @@ Hardware requirements for SWC testnet nodes can vary depending on the type of no
 | [make](https://linux.die.net/man/1/make)                      | `^3`     | `make --version`      |
 | [just](https://just.systems/man/en/packages.html)             | `^1.34`  | `just --version`      |
 
+## Sync modes
+
+The following configurations are available for running a node ([explanation](https://docs.optimism.io/operators/node-operators/management/snap-sync#enable-snap-sync-for-your-node)):
+
+|                        |`op-node`(CL)                                  | `op-geth`(EL)                       |
+|--                      |--                                         |--                               |
+|Full nodes EL snap sync |`--syncmode=execution-layer (not default)` | `--syncmode=snap (default)`     |
+|Full nodes EL full sync |`--syncmode=execution-layer (not default)` | `--syncmode=full (not default)`                                             |
+|Full nodes CL sync      |`--syncmode=consensus-layer (default)`     | `--syncmode=full (not default)` |
+
+For archive nodes, please add `--gcmode=archive` to `op-geth`.
+
+
 ## Beta Testnet
 
 ### Steps
@@ -136,14 +149,3 @@ Hardware requirements for SWC testnet nodes can vary depending on the type of no
          ./bin/op-node   --l2=http://localhost:8551   --l2.jwt-secret=./jwt.txt   --verifier.l1-confs=4   --rollup.config=./devnet_rollup.json  --rpc.port=8547   --p2p.static=/ip4/65.109.20.29/tcp/9003/p2p/16Uiu2HAmP3KorAMS1DC5SdDEcNGwhMFKuoyvZzBSWXdqysZgrxQ7 --p2p.listen.ip=0.0.0.0 --p2p.listen.tcp=9003 --p2p.listen.udp=9003  --p2p.no-discovery --p2p.sync.onlyreqtostatic --rpc.enable-admin   --l1=$L1_RPC_URL   --l1.rpckind=$L1_RPC_KIND --l1.beacon=$L1_BEACON_URL --l1.beacon-archiver=http://65.108.236.27:9645
     ```
  
-## Sync modes
-
-The following configurations are available for running a node ([explanation](https://docs.optimism.io/operators/node-operators/management/snap-sync#enable-snap-sync-for-your-node)):
-
-|                        |`op-node`(CL)                                  | `op-geth`(EL)                       |
-|--                      |--                                         |--                               |
-|Full nodes EL snap sync |`--syncmode=execution-layer (not default)` | `--syncmode=snap (default)`     |
-|Full nodes EL full sync |`--syncmode=execution-layer (not default)` | `--syncmode=full (not default)`                                             |
-|Full nodes CL sync      |`--syncmode=consensus-layer (default)`     | `--syncmode=full (not default)` |
-
-For archive nodes, please add `--gcmode=archive` to `op-geth`.

--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -21,7 +21,7 @@ Hardware requirements for SWC testnet nodes can vary depending on the type of no
 
 ## Sync modes
 
-The following configurations are available for running a node ([explanation](https://docs.optimism.io/operators/node-operators/management/snap-sync#enable-snap-sync-for-your-node)):
+For full nodes, the following configurations are available ([explanation](https://docs.optimism.io/operators/node-operators/management/snap-sync#enable-snap-sync-for-your-node)):
 
 |                        |`op-node`(CL)                                  | `op-geth`(EL)                       |
 |--                      |--                                         |--                               |
@@ -146,6 +146,6 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
 
         # Ensure to replace --p2p.static with the sequencer's address.
         # Note: p2p is enabled for unsafe block.
-         ./bin/op-node   --l2=http://localhost:8551   --l2.jwt-secret=./jwt.txt   --verifier.l1-confs=4   --rollup.config=./devnet_rollup.json  --rpc.port=8547   --p2p.static=/ip4/65.109.20.29/tcp/9003/p2p/16Uiu2HAmP3KorAMS1DC5SdDEcNGwhMFKuoyvZzBSWXdqysZgrxQ7 --p2p.listen.ip=0.0.0.0 --p2p.listen.tcp=9003 --p2p.listen.udp=9003  --p2p.no-discovery --p2p.sync.onlyreqtostatic --rpc.enable-admin   --l1=$L1_RPC_URL   --l1.rpckind=$L1_RPC_KIND --l1.beacon=$L1_BEACON_URL --l1.beacon-archiver=http://65.108.236.27:9645
+         ./bin/op-node   --l2=http://localhost:8551   --l2.jwt-secret=./jwt.txt   --verifier.l1-confs=4   --rollup.config=./devnet_rollup.json  --rpc.port=8547   --p2p.static=/ip4/65.109.20.29/tcp/9003/p2p/16Uiu2HAmP3KorAMS1DC5SdDEcNGwhMFKuoyvZzBSWXdqysZgrxQ7 --p2p.listen.ip=0.0.0.0 --p2p.listen.tcp=9003 --p2p.listen.udp=9003  --p2p.no-discovery --p2p.sync.onlyreqtostatic --rpc.enable-admin   --l1=$L1_RPC_URL   --l1.rpckind=$L1_RPC_KIND --l1.beacon=$L1_BEACON_URL --l1.beacon-archiver=http://65.108.236.27:9645 --syncmode=execution-layer
     ```
  

--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -138,19 +138,12 @@ Hardware requirements for SWC testnet nodes can vary depending on the type of no
  
 ## Sync modes
 
-The execution layer (`op-geth`) supports two sync modes:  
-- **Snap sync** (default)  
-- **Full sync**  
+The following configurations are available for running a node ([explanation](https://docs.optimism.io/operators/node-operators/management/snap-sync#enable-snap-sync-for-your-node)):
 
-The consensus layer (`op-node`) also supports two sync modes:  
-- **Execution layer (EL) sync**: This is the recommended option. In this mode, `op-node` instructs `op-geth` to perform a snap sync. Once `op-geth` downloads the state at the tip, it switches to inserting blocks one by one.  
-- **Consensus layer (CL) sync** (default): This mode is ideal for decentralized developer groups requiring full chain verification, as `op-node` derives every L2 block from Ethereum.  
+|                        |`op-node`(CL)                                  | `op-geth`(EL)                       |
+|--                      |--                                         |--                               |
+|Full nodes EL snap sync |`--syncmode=execution-layer (not default)` | `--syncmode=snap (default)`     |
+|Full nodes EL full sync |`--syncmode=execution-layer (not default)` | `--syncmode=full (not default)`                                             |
+|Full nodes CL sync      |`--syncmode=consensus-layer (default)`     | `--syncmode=full (not default)` |
 
-Based on these options, the following configurations are available for running a node:
-
-|                     |`op-node`                                  | `op-geth`                                                               |
-|--                   |--                                         |--                                                                       |
-|Full nodes snap sync |`--syncmode=execution-layer (not default)` | `--syncmode=snap (default)`                                             |
-|Full nodes full sync |`--syncmode=execution-layer (not default)` | `--syncmode=full (not default)`                                             |
-|Archive nodes EL sync|`--syncmode=execution-layer (not default)` | `--syncmode=full (not default)` <br> `--gcmode=archive (not default)`   |
-|Archive Nodes CL sync|`--syncmode=consensus-layer (default)`     | `--syncmode=full (not default)` <br> `--gcmode=archive (not default)`   |
+For archive nodes, please add `--gcmode=archive` to `op-geth`.

--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -1,6 +1,14 @@
-# Run a Super World Computer node
+# Run a Super World Computer(SWC) node
 
-This guide will help you get a Super World Computer node up and running.
+This guide will help you get SWC node up and running.
+
+## Hardware requirements
+
+Hardware requirements for SWC testnet nodes can vary depending on the type of node you plan to run. Archive nodes generally require significantly more resources than full nodes. Below are suggested minimum hardware requirements for each type of node.
+
+- 8GB RAM
+- 60 GB SSD (full node) or 200 GB SSD (archive node)
+- Reasonably modern CPU
 
 ## Software dependencies
 
@@ -30,6 +38,10 @@ This guide will help you get a Super World Computer node up and running.
 
 2. Setup `op-geth`:
 
+> * Set `--syncmode=execution-layer` on `op-node` if you don't set `--syncmode=full` here on op-geth. 
+> * For archive nodes, set `--syncmode=full` and `--gcmode=archive` on `op-geth`.
+> * The default settings are for full nodes with snap sync.
+
     ```bash
         # assume optimism and op-geth repo are located at ./optimism and ./op-geth
 
@@ -42,10 +54,15 @@ This guide will help you get a Super World Computer node up and running.
 
         # We don't specify `--rollup.sequencerhttp` since it's for testing blob archiver only.
         # The rpc port is the default one: 8545.
-        ./build/bin/geth   --datadir ./datadir   --http   --http.corsdomain="*"   --http.vhosts="*"   --http.addr=0.0.0.0   --http.api=web3,debug,eth,txpool,net,engine   --ws   --ws.addr=0.0.0.0   --ws.port=8546   --ws.origins="*"   --ws.api=debug,eth,txpool,net,engine   --syncmode=full   --gcmode=archive   --nodiscover   --maxpeers=0   --networkid=3335   --authrpc.vhosts="*"   --authrpc.addr=0.0.0.0   --authrpc.port=8551   --authrpc.jwtsecret=./jwt.txt   --rollup.disabletxpoolgossip=true
+        ./build/bin/geth   --datadir ./datadir   --http   --http.corsdomain="*"   --http.vhosts="*"   --http.addr=0.0.0.0   --http.api=web3,debug,eth,txpool,net,engine   --ws   --ws.addr=0.0.0.0   --ws.port=8546   --ws.origins="*"   --ws.api=debug,eth,txpool,net,engine  --networkid=3335   --authrpc.vhosts="*"   --authrpc.addr=0.0.0.0   --authrpc.port=8551   --authrpc.jwtsecret=./jwt.txt   --rollup.disabletxpoolgossip=true
     ```
 
 3. Setup `op-node`:
+
+> ⚠️ The `op-node` RPC should not be exposed publicly. If left exposed, it could accidentally expose admin controls to the public internet. 
+
+> Sync mode is set to `--syncmode=execution-layer` to enable snap sync.
+
     ```bash
         # assume optimism and op-geth repo are located at ./optimism and ./op-geth
         # copy jwt.txt from the op-geth directory above to optimism/op-node
@@ -61,7 +78,7 @@ This guide will help you get a Super World Computer node up and running.
         mkdir safedb
         # Ensure to replace --p2p.static with the sequencer's address.
         # Note: p2p is enabled for unsafe block.
-        ./bin/op-node   --l2=http://localhost:8551   --l2.jwt-secret=./jwt.txt   --verifier.l1-confs=4   --rollup.config=./beta_testnet_rollup.json   --rpc.addr=0.0.0.0   --rpc.port=8547   --p2p.static=/ip4/5.9.87.214/tcp/9003/p2p/16Uiu2HAm2w9ZsnP58zzGpPXGuCH8j6w9ecwA3uwXhkXxJniJEbUX --p2p.listen.ip=0.0.0.0 --p2p.listen.tcp=9003 --p2p.listen.udp=9003  --p2p.no-discovery --p2p.sync.onlyreqtostatic --rpc.enable-admin   --l1=$L1_RPC_URL   --l1.rpckind=$L1_RPC_KIND --l1.beacon=$L1_BEACON_URL --l1.beacon-archiver=http://65.108.236.27:9645 --safedb.path=safedb
+        ./bin/op-node   --l2=http://localhost:8551   --l2.jwt-secret=./jwt.txt   --verifier.l1-confs=4   --rollup.config=./beta_testnet_rollup.json  --rpc.port=8547   --p2p.static=/ip4/5.9.87.214/tcp/9003/p2p/16Uiu2HAm2w9ZsnP58zzGpPXGuCH8j6w9ecwA3uwXhkXxJniJEbUX --p2p.listen.ip=0.0.0.0 --p2p.listen.tcp=9003 --p2p.listen.udp=9003  --p2p.no-discovery --p2p.sync.onlyreqtostatic --rpc.enable-admin   --l1=$L1_RPC_URL   --l1.rpckind=$L1_RPC_KIND --l1.beacon=$L1_BEACON_URL --l1.beacon-archiver=http://65.108.236.27:9645 --safedb.path=safedb --syncmode=execution-layer
     ```
 
 ---


### PR DESCRIPTION
## Description
- fix https://github.com/QuarkChain/op-geth/issues/1, caused by node discovery not being enabled
- add hardware requirements section
- remove public RPC option in `op-node` 