### PR TITLE
add CGT address

### DIFF
--- a/network-reference/contract-addresses.md
+++ b/network-reference/contract-addresses.md
@@ -4,6 +4,7 @@
 
 ```json
 {
+    "customGasToken": "0xe6ABD81D16a20606a661D4e075cdE5734AB62519",
     "superchainDeployment": {
       "proxyAdminAddress": "0xf0e84441f20cdece7c8677a43cd76c5357604ea5",
       "superchainConfigProxyAddress": "0x1f3cc237822e4a96e36aab29483a69866108518c",


### PR DESCRIPTION
Previously the `Contract addresses` are solely the output of op-deployer, so the CGT address is not listed, and user needs to query it via system config [here](https://github.com/QuarkChain/optimism/blob/beta_contracts/packages/contracts-bedrock/src/L1/SystemConfig.sol#L296).

This PR manually adds the CGT address into the `Contract addresses` for easier reference.

TBH, I'm not sure whether it's better to put it in the `RPC configurations` like what we did for the devnet before.

So we can also use this PR to discuss if you think `RPC configurations` is a better place for this info.

