### PR TITLE
remove `--enablel2blob`

### DIFF
--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -128,7 +128,7 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
 
         # We don't specify `--rollup.sequencerhttp` since it's for testing blob archiver only.
         # The rpc port is the default one: 8545.
-        ./build/bin/geth   --datadir ./datadir   --http   --http.corsdomain="*"   --http.vhosts="*"   --http.addr=0.0.0.0   --http.api=web3,debug,eth,txpool,net,engine   --ws   --ws.addr=0.0.0.0   --ws.port=8546   --ws.origins="*"   --ws.api=debug,eth,txpool,net,engine  --networkid=42069   --authrpc.vhosts="*"   --authrpc.addr=0.0.0.0   --authrpc.port=8551   --authrpc.jwtsecret=./jwt.txt   --rollup.disabletxpoolgossip=true --enablel2blob
+        ./build/bin/geth   --datadir ./datadir   --http   --http.corsdomain="*"   --http.vhosts="*"   --http.addr=0.0.0.0   --http.api=web3,debug,eth,txpool,net,engine   --ws   --ws.addr=0.0.0.0   --ws.port=8546   --ws.origins="*"   --ws.api=debug,eth,txpool,net,engine  --networkid=42069   --authrpc.vhosts="*"   --authrpc.addr=0.0.0.0   --authrpc.port=8551   --authrpc.jwtsecret=./jwt.txt   --rollup.disabletxpoolgossip=true
     ```
  
  3. Setup `op-node`:


### PR DESCRIPTION
This option has been removed in https://github.com/ethstorage/op-geth/pull/5.