### PR TITLE
Adjustment for mainnet

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,13 +17,11 @@
 ## Guides
 
 * App Developers
-  * [Receive tokens](guides/app-developers/receive-tokens.md)
+  * [Receive test tokens](guides/app-developers/receive-tokens.md)
   * [Bridge tokens](guides/app-developers/bridge-tokens.md)
-  * [EthStorage Usage Guide](guides/app-developers/es-usage-guide.md)
 * Node Operators
   * [Run an Ethereum node](guides/node-operators/run-a-ethereum-node.md)
   * [Run a Super World Computer node](guides/node-operators/run-a-super-world-computer-node.md)
-  * [Run op-challenger](guides/node-operators/op-challenger.md)
 
 ## Network Reference
 
@@ -34,6 +32,7 @@
 
 * [`op-node` forkdiff](https://op-node.quarkchain.io/)
 * [`op-geth` forkdiff](https://op-geth.quarkchain.io/)
+* [`op-contract` forkdiff](https://op-contract.quarkchain.io/)
 
 ## Others
 

--- a/guides/app-developers/bridge-tokens.md
+++ b/guides/app-developers/bridge-tokens.md
@@ -1,3 +1,7 @@
-## Delta Testnet
+## Mainnet
+ - Native QKC Bridge: https://migration.mainnet.l2.quarkchain.io
+ - ERC20 Bridge: https://bridge.mainnet.l2.quarkchain.io
 
-Visit [the bridge](https://bridge.delta.testnet.l2.quarkchain.io/) and follow through the UI.
+## Delta Testnet
+ - Native QKC Bridge: https://migration.delta.testnet.l2.quarkchain.io
+ - ERC20 Bridge: https://bridge.delta.testnet.l2.quarkchain.io

--- a/guides/node-operators/run-a-super-world-computer-node.md
+++ b/guides/node-operators/run-a-super-world-computer-node.md
@@ -4,20 +4,11 @@ This guide will help you get SWC node up and running.
 
 ## Hardware requirements
 
-Hardware requirements for SWC testnet nodes can vary depending on the type of node you plan to run. Archive nodes generally require significantly more resources than full nodes. Below are suggested minimum hardware requirements for each type of node.
+Hardware requirements for SWC nodes can vary depending on the type of node you plan to run. Archive nodes generally require significantly more resources than full nodes. Below are suggested minimum hardware requirements for each type of node.
 
 - 8GB RAM
-- 60 GB SSD (full node) or 200 GB SSD (archive node)
+- 300 GB SSD (full node) or 500 GB SSD (archive node)
 - Reasonably modern CPU
-
-## Software dependencies
-
-| Dependency                                        | Version | Version Check Command |
-| ------------------------------------------------- | ------- | --------------------- |
-| [git](https://git-scm.com/)                       | `^2`    | `git --version`       |
-| [go](https://go.dev/)                             | `^1.21` | `go version`          |
-| [make](https://linux.die.net/man/1/make)          | `^3`    | `make --version`      |
-| [just](https://just.systems/man/en/packages.html) | `^1.34` | `just --version`      |
 
 ## Sync modes
 
@@ -31,7 +22,109 @@ For full nodes, the following configurations are available ([explanation](https:
 
 For archive nodes, please add `--gcmode=archive` to `op-geth`.
 
+## Mainnet
+
+### Steps
+
+1. Follow the following steps to download the executable binaries.
+
+ - 1.1 Download `op-geth`  
+    ```bash
+    export VERSION=v1.0.0
+    curl -L "https://github.com/QuarkChain/op-geth/releases/download/${VERSION}/op-geth.${VERSION}.linux-amd64.tar.gz" \
+      | tar -xz && mv "op-geth.${VERSION}" op-geth
+    ```
+- 1.2 Download `op-node`
+    ```bash
+    export VERSION=v1.0.0
+    curl -L "https://github.com/QuarkChain/optimism/releases/download/op-node%2F${VERSION}/op-node.${VERSION}.linux-amd64.tar.gz" \
+      | tar -xz --strip-components=1 && mv "${VERSION}" op-node
+    ```
+2. Setup `op-geth`:
+
+    > The default settings are for full nodes with snap sync. For configurations related to full sync or archive nodes, please refer to the [Sync modes](#sync-modes) section.
+
+    ```bash
+        # assume op-node and op-geth are located at ./op-node and ./op-geth
+
+        cd op-geth
+        # prepare mainnet_genesis.json
+        curl -LO https://raw.githubusercontent.com/QuarkChain/pm/refs/heads/main/L2/assets/mainnet_genesis.json
+        ./build/bin/geth init --datadir=datadir --state.scheme hash mainnet_genesis.json
+        openssl rand -hex 32 > jwt.txt
+
+        export PUBLIC_IP=<YOUR_PUBLIC_IP>
+
+        # The rpc port is the default one: 8545.
+        ./build/bin/geth --datadir ./datadir   \
+            --http \
+            --http.corsdomain="*" \
+            --http.vhosts="*" \
+            --http.addr=0.0.0.0 \
+            --http.api=web3,eth,txpool,net \
+            --ws \
+            --ws.addr=0.0.0.0 \
+            --ws.port=8546 \
+            --ws.origins="*" \
+            --ws.api=eth,txpool,net \
+            --nat="extip:${PUBLIC_IP}" \
+            --networkid=100011 \
+            --authrpc.vhosts="*" \
+            --authrpc.port=8551 \
+            --authrpc.jwtsecret=./jwt.txt \
+            --rollup.disabletxpoolgossip \
+            --rollup.sequencerhttp=https://rpc.mainnet.l2.quarkchain.io:8545 \
+            --rollup.enabletxpooladmission 2>&1 | tee -a geth.log -i
+    ```
+
+3. Setup `op-node`:
+
+    > ⚠️ The `op-node` admin RPC should not be exposed publicly. If left exposed, it could accidentally expose admin controls to the public internet. 
+
+    > Sync mode is set to `--syncmode=execution-layer` to enable snap sync.
+
+    ```bash
+        # assume op-node and op-geth are located at ./op-node and ./op-geth
+        # copy jwt.txt from the op-geth directory above to ./op-node
+        cp ./op-geth/jwt.txt ./op-node 
+        cd ./op-node
+
+        export L1_RPC_KIND=basic
+        export L1_RPC_URL=<YOUR_RPC_URL>
+        export L1_BEACON_URL=<YOUR_BEACON_URL>
+        # prepare delta_testnet_rollup.json
+        curl -LO https://raw.githubusercontent.com/QuarkChain/pm/refs/heads/main/L2/assets/mainnet_rollup.json
+        mkdir safedb
+
+        export PUBLIC_IP=<YOUR_PUBLIC_IP>
+
+        ./build/bin/op-node --l2=http://localhost:8551 \
+            --l2.jwt-secret=./jwt.txt \
+            --verifier.l1-confs=4 \
+            --rollup.config=./mainnet_rollup.json \
+            --rpc.port=8547 \
+            --p2p.listen.ip=0.0.0.0 \
+            --p2p.listen.tcp=9003 \
+            --p2p.listen.udp=9003 \
+            --p2p.advertise.ip=$PUBLIC_IP \
+            --l1=$L1_RPC_URL \
+            --l1.rpckind=$L1_RPC_KIND \
+            --l1.beacon=$L1_BEACON_URL \
+            --l1.beacon-archiver=https://archive.mainnet.ethstorage.io:9645 \
+            --l1.cache-size=0 \
+            --safedb.path=safedb \
+            --syncmode=execution-layer | tee -a node.log -i
+
 ## Delta Testnet
+
+### Software dependencies
+
+| Dependency                                        | Version | Version Check Command |
+| ------------------------------------------------- | ------- | --------------------- |
+| [git](https://git-scm.com/)                       | `^2`    | `git --version`       |
+| [go](https://go.dev/)                             | `^1.21` | `go version`          |
+| [make](https://linux.die.net/man/1/make)          | `^3`    | `make --version`      |
+| [just](https://just.systems/man/en/packages.html) | `^1.34` | `just --version`  
 
 ### Steps
 
@@ -59,8 +152,9 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
         # prepare gamma_testnet_genesis.json
         curl -LO https://raw.githubusercontent.com/QuarkChain/pm/main/L2/assets/delta_testnet_genesis.json
         ./build/bin/geth init --datadir=datadir --state.scheme hash delta_testnet_genesis.json
-
         openssl rand -hex 32 > jwt.txt
+
+        export PUBLIC_IP=<YOUR_PUBLIC_IP>
 
         # The rpc port is the default one: 8545.
         ./build/bin/geth --datadir ./datadir   \
@@ -74,14 +168,14 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
             --ws.port=8546 \
             --ws.origins="*" \
             --ws.api=eth,txpool,net \
+            --nat="extip:${PUBLIC_IP}" \
             --networkid=110011 \
             --authrpc.vhosts="*" \
             --authrpc.port=8551 \
             --authrpc.jwtsecret=./jwt.txt \
             --rollup.disabletxpoolgossip \
             --rollup.sequencerhttp=http://65.109.110.98:8545 \
-            --rollup.enabletxpooladmission \
-            --bootnodes enode://bca0a705e3ff2dd759724ed4b95a5ce01dc23c4fa0e208828cf275be77b7014dbad551e566cd557f56065e04d435800ae1223e5e060301ea8ad77b9714fc815f@65.109.110.98:30303 2>&1 | tee -a geth.log -i
+            --rollup.enabletxpooladmission 2>&1 | tee -a geth.log -i
     ```
 
 3. Setup `op-node`:
@@ -102,6 +196,7 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
         # prepare delta_testnet_rollup.json
         curl -LO https://raw.githubusercontent.com/QuarkChain/pm/main/L2/assets/delta_testnet_rollup.json
 
+        export PUBLIC_IP=<YOUR_PUBLIC_IP>
         mkdir safedb
         # Ensure to replace --p2p.static with the sequencer's address.
         # Note: p2p is enabled for unsafe block.
@@ -110,13 +205,10 @@ For archive nodes, please add `--gcmode=archive` to `op-geth`.
             --verifier.l1-confs=4 \
             --rollup.config=./delta_testnet_rollup.json \
             --rpc.port=8547 \
-            --rpc.enable-admin \
-            --p2p.static=/ip4/65.109.110.98/tcp/9003/p2p/16Uiu2HAmUz5ueaopZhJP4VE3qDqFKSAyLdxq7aNPo3FiWMkj8Nze \
             --p2p.listen.ip=0.0.0.0 \
             --p2p.listen.tcp=9003 \
             --p2p.listen.udp=9003 \
-            --p2p.no-discovery \
-            --p2p.sync.onlyreqtostatic \
+            --p2p.advertise.ip=$PUBLIC_IP \
             --l1=$L1_RPC_URL \
             --l1.rpckind=$L1_RPC_KIND \
             --l1.beacon=$L1_BEACON_URL \

--- a/network-reference/contract-addresses.md
+++ b/network-reference/contract-addresses.md
@@ -1,3 +1,63 @@
+## Mainnet
+
+### Mainnet L1 address
+
+```json
+{
+    "SuperchainProxyAdminImpl": "0x39f6ef46f0c1fb978298ef9fdb7a600610f65875",
+    "SuperchainConfigProxy": "0x6b97e18104389b63779396e91073ec9b4388d7c6",
+    "SuperchainConfigImpl": "0xce28685eb204186b557133766eca00334eb441e4",
+    "ProtocolVersionsProxy": "0xa838dfa10d304f5b67db5041ce29ddf49d9a847f",
+    "ProtocolVersionsImpl": "0x37e15e4d6dffa9e5e320ee1ec036922e563cb76c",
+    "OpcmImpl": "0xcbf13801164dddc86d0895805b36769b70361c41",
+    "OpcmContractsContainerImpl": "0x0000000000000000000000000000000000000000",
+    "OpcmGameTypeAdderImpl": "0x1805e56a77e927495dd4ed9ca4cc5c04ee7b2910",
+    "OpcmDeployerImpl": "0xde7158538e03a0bd22530a512562a16feb218760",
+    "OpcmUpgraderImpl": "0x2b4a81b83ce461a4fcf9a3c1768a1a974a3fea2d",
+    "OpcmInteropMigratorImpl": "0x881f2542fe1bda0ffddba2e79f83f2472bd2824d",
+    "OpcmStandardValidatorImpl": "0xdb3a0eba8d936e8d994dd7851609b2cc4213b7df",
+    "DelayedWethImpl": "0x33dadc2d1aa9bb613a7ae6b28425ea00d44c6998",
+    "OptimismPortalImpl": "0x9ef630d9d41adac7ab6d67d6e2f6afbdc20d43e0",
+    "OptimismPortalInteropImpl": "0xb0eb854fd842e0e564d49d2fe6b2ac25d035523c",
+    "EthLockboxImpl": "0x784d2f03593a42a6e4676a012762f18775ecbbe6",
+    "PreimageOracleImpl": "0x1fb8cdfc6831fc866ed9c51af8817da5c287add3",
+    "MipsImpl": "0x07babe08ee4d07dba236530183b24055535a7011",
+    "SystemConfigImpl": "0x2bfe4a5bd5a41e9d848d843ebcdfa15954e9a557",
+    "L1CrossDomainMessengerImpl": "0x22d12e0faebd62d429514a65ebae32dd316c12d6",
+    "L1Erc721BridgeImpl": "0x7f1d12fb2911eb095278085f721e644c1f675696",
+    "L1StandardBridgeImpl": "0xe32b192fb1dca88fcb1c56b3acb429e32238adcb",
+    "OptimismMintableErc20FactoryImpl": "0x5493f4677a186f64805fe7317d6993ba4863988f",
+    "DisputeGameFactoryImpl": "0x33d1e8571a85a538ed3d5a4d88f46c112383439d",
+    "AnchorStateRegistryImpl": "0x0875282c0ba2958094312eec447d0d8186033838",
+    "OpChainProxyAdminImpl": "0x75025088b628aa01e52a5d770f7cec62cbd7add4",
+    "OptimismPortalProxy": "0xf9ea3f50acbacb122bfb9ceb6cf79c6cfcf35c7a",
+    "AddressManagerImpl": "0xcda65dcad63986b991fcf80e9c6293e82bc8f33e",
+    "L1Erc721BridgeProxy": "0x6415832dfb88d8e02237a6aa691a3b79a12c8f27",
+    "SystemConfigProxy": "0xbb8bed33614599947d5ca1844de546e59ea50e7a",
+    "OptimismMintableErc20FactoryProxy": "0xcccb929fdcaa6e15f40aef3b78d8a006228501c4",
+    "L1StandardBridgeProxy": "0x326798c62fc0d7281f3840e08226a671aa949e98",
+    "L1CrossDomainMessengerProxy": "0x3137f7b40e58d9babb62f63924314ef037c400cb",
+    "EthLockboxProxy": "0x961395673c7273cac77852a4c010c060fd75b0f7",
+    "DisputeGameFactoryProxy": "0x61870a40eaa988515060e91e39da9c4a690b5c9b",
+    "AnchorStateRegistryProxy": "0xe3f46bd5f116b3878bc5bbd95d306f876e907889",
+    "FaultDisputeGameImpl": "0x0000000000000000000000000000000000000000",
+    "PermissionedDisputeGameImpl": "0xfb8a8c7ec1a3bf0ab19e7734d9aaf3964ab165de",
+    "DelayedWethPermissionedGameProxy": "0xc2b857d7cc34b546c2f050dfc73bda1028224eab",
+    "DelayedWethPermissionlessGameProxy": "0x0000000000000000000000000000000000000000",
+    "AltDAChallengeProxy": "0x0000000000000000000000000000000000000000",
+    "AltDAChallengeImpl": "0x0000000000000000000000000000000000000000",
+    "L2OutputOracleProxy": "0x0000000000000000000000000000000000000000"
+}
+```
+
+### Mainnet L2 addresses
+
+```json
+{
+  "SoulGasToken": "0x4200000000000000000000000000000000000800"
+}
+```
+
 ## Delta Testnet
 
 ### Delta Testnet L1 address

--- a/network-reference/rpc-configuration.md
+++ b/network-reference/rpc-configuration.md
@@ -1,4 +1,13 @@
-## Delta Test
+## Mainnet
+
+```
+Bridge: https://bridge.mainnet.l2.quarkchain.io
+Token Migration: https://migration.mainnet.l2.quarkchain.io
+Explorer：https://explorer.mainnet.l2.quarkchain.io
+RPC: https://rpc.mainnet.l2.quarkchain.io:8545
+```
+
+## Delta Testnet
 
 ```
 Bridge: https://bridge.delta.testnet.l2.quarkchain.io


### PR DESCRIPTION
Adjustments: 
- Adding mainnet rpc info.
 - Use executale binary to run mainnet full node.
 - Rename the "Receive Tokens" page title to "Receive Test Tokens"
 - Hide "EthStorage Usage Guide", as L2 Blobs are not enabled on either testnet or mainnet.
 - Hide "Run op-challenger" since we are operating in permissioned mode and the community cannot run challengers.
 - Add https://op-contract.quarkchain.io to the Forkdiff section.